### PR TITLE
GitHub.parseReleasesJson: use tag_name if name is blank

### DIFF
--- a/app/src/main/java/com/jroddev/android_oss_release_tracker/repo/GitHub.kt
+++ b/app/src/main/java/com/jroddev/android_oss_release_tracker/repo/GitHub.kt
@@ -39,7 +39,7 @@ class GitHub : CommonRepo() {
         val firstEntry = data.get(0) as JSONObject
 
         return LatestVersionData(
-            version = cleanVersionName(firstEntry.getString("name")),
+            version = cleanVersionName(firstEntry.getString("name").ifBlank { firstEntry.getString("tag_name") }),
             url = firstEntry.getString("html_url"),
             date = firstEntry.getString("published_at")
         )


### PR DESCRIPTION
Currently, the latest version is "unknown" for my apps because I never add a release title (since it would just be the same as the tag name).

This change -- using `tag_name` instead when `name` is blank -- should make it work correctly for my apps as well.

NB: I haven't actually been able to test the modified code (since I currently don't have a working android dev environment).

Also: I haven't really used GitLab releases myself before, but I imagine the same issue (and a similar fix) may apply there.