### PR TITLE
Add Fdroid Button/Badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 - Opens new version in browser for you to install yourself
 - Bulk Import and Export of repo list
 
-<p align="left"><a href="https://apt.izzysoft.de/fdroid/index/apk/com.jroddev.android_oss_release_tracker"><img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height=80/></a></p>
+[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
+     alt="Get it on F-Droid"
+     height="80">](https://f-droid.org/packages/com.jroddev.android_oss_release_tracker/)
+
+or get the APK from the [Releases Section](https://github.com/jroddev/android-oss-release-tracker/releases/latest).
 
 ---
 


### PR DESCRIPTION
Hi,

This small PR adds a button to get your app on F-Droid and a link to get the apk from the releases section. You can later add a button for Google Play the same way :
`[<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
      alt="Get it on Google Play"
      height="80">]()`

You can now eventually add the [fdroid](https://github.com/topics/fdroid) and/or [f-droid](https://github.com/topics/f-droid) tags that will appear on the right side of the repo.